### PR TITLE
Add __tb_alloc_trace__ macro and code to trace memory allocations/dea…

### DIFF
--- a/src/tbox/asio/aicp.c
+++ b/src/tbox/asio/aicp.c
@@ -92,7 +92,7 @@ static tb_bool_t tb_aicp_post_after_func(tb_aice_ref_t aice)
 #ifdef __tb_debug__
         if (!tb_aicp_post_((tb_aicp_ref_t)impl, posted_aice, ((tb_aico_impl_t*)aice->aico)->func, ((tb_aico_impl_t*)aice->aico)->line, ((tb_aico_impl_t*)aice->aico)->file))
 #else
-        if (!tb_aicp_post_((tb_aicp_ref_t)impl, posted_aice))
+        if (!tb_aicp_post_((tb_aicp_ref_t)impl, posted_aice __tb_debug_vals__))
 #endif
         {
             // not posted

--- a/src/tbox/memory/allocator.c
+++ b/src/tbox/memory/allocator.c
@@ -79,6 +79,9 @@ tb_pointer_t tb_allocator_malloc_(tb_allocator_ref_t allocator, tb_size_t size _
     // leave
     tb_spinlock_leave(&allocator->lock);
 
+#ifdef __tb_alloc_trace__
+    tb_trace_w("tb_allocator_malloc_(%p): %lu", data, size, func_, line_, file_);
+#endif
     // ok?
     return data;
 }
@@ -87,8 +90,14 @@ tb_pointer_t tb_allocator_malloc0_(tb_allocator_ref_t allocator, tb_size_t size 
     // check
     tb_assert_and_check_return_val(allocator, tb_null);
 
+#ifdef __tb_alloc_trace__
+    tb_trace_w("tb_allocator_malloc0_(): %lu", size, func_, line_, file_);
+#endif
     // malloc it
     tb_pointer_t data = tb_allocator_malloc_(allocator, size __tb_debug_args__);
+#ifdef __tb_alloc_trace__
+    tb_trace_w("tb_allocator_malloc0_(%p): %lu", data, size, func_, line_, file_);
+#endif
 
     // clear it
     if (data) tb_memset_(data, 0, size);
@@ -152,6 +161,9 @@ tb_pointer_t tb_allocator_ralloc_(tb_allocator_ref_t allocator, tb_pointer_t dat
     // leave
     tb_spinlock_leave(&allocator->lock);
 
+#ifdef __tb_alloc_trace__
+    tb_trace_w("tb_allocator_ralloc_(%p): %lu (%p)", data_new, size, data, func_, line_, file_);
+#endif
     // ok?
     return data_new;
 }
@@ -186,6 +198,9 @@ tb_bool_t tb_allocator_free_(tb_allocator_ref_t allocator, tb_pointer_t data __t
     // leave
     tb_spinlock_leave(&allocator->lock);
 
+#ifdef __tb_alloc_trace__
+    tb_trace_w("tb_allocator_free_(%p)", data, func_, line_, file_);
+#endif
     // ok?
     return ok;
 }

--- a/src/tbox/prefix/keyword.h
+++ b/src/tbox/prefix/keyword.h
@@ -122,7 +122,7 @@
 #endif
 
 // debug
-#ifdef __tb_debug__
+#if defined(__tb_debug__) || defined(__tb_alloc_trace__)
 #   define __tb_debug_decl__                    , tb_char_t const* func_, tb_size_t line_, tb_char_t const* file_
 #   define __tb_debug_vals__                    , __tb_func__, __tb_line__, __tb_file__
 #   define __tb_debug_args__                    , func_, line_, file_

--- a/src/tbox/prefix/trace.h
+++ b/src/tbox/prefix/trace.h
@@ -58,7 +58,7 @@ __tb_extern_c_enter__
 #if defined(TB_COMPILER_IS_GCC)
 #   define tb_trace_p(prefix, fmt, arg ...)                 do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, fmt __tb_newline__, ## arg); } while (0)
 #   define tb_tracef_p(prefix, fmt, arg ...)                do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, fmt, ## arg); } while (0)
-#   ifdef __tb_debug__
+#   if defined(__tb_debug__) || defined(__tb_alloc_trace__)
 #       define tb_trace_error_p(prefix, fmt, arg ...)       do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, "[error]: " fmt " at %s(): %d, %s" __tb_newline__, ##arg, __tb_func__, __tb_line__, __tb_file__); tb_trace_sync(); } while (0)
 #       define tb_trace_assert_p(prefix, fmt, arg ...)      do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, "[assert]: " fmt " at %s(): %d, %s" __tb_newline__, ##arg, __tb_func__, __tb_line__, __tb_file__); tb_trace_sync(); } while (0)
 #       define tb_trace_warning_p(prefix, fmt, arg ...)     do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, "[warning]: " fmt " at %s(): %d, %s" __tb_newline__, ##arg, __tb_func__, __tb_line__, __tb_file__); tb_trace_sync(); } while (0)
@@ -76,7 +76,7 @@ __tb_extern_c_enter__
 #elif defined(TB_COMPILER_IS_MSVC) && TB_COMPILER_VERSION_BE(13, 0)
 #   define tb_trace_p(prefix, fmt, ...)                     do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, fmt __tb_newline__, __VA_ARGS__); } while (0)
 #   define tb_tracef_p(prefix, fmt, ...)                    do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, fmt, __VA_ARGS__); } while (0)
-#   ifdef __tb_debug__
+#   if defined(__tb_debug__) || defined(__tb_alloc_trace__)
 #       define tb_trace_error_p(prefix, fmt, ...)           do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, "[error]: at %s(): %d, %s: " fmt __tb_newline__, __tb_func__, __tb_line__, __tb_file__, __VA_ARGS__); tb_trace_sync(); } while (0)
 #       define tb_trace_assert_p(prefix, fmt, ...)          do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, "[assert]: at %s(): %d, %s: " fmt __tb_newline__, __tb_func__, __tb_line__, __tb_file__, __VA_ARGS__); tb_trace_sync(); } while (0)
 #       define tb_trace_warning_p(prefix, fmt, ...)         do { tb_trace_done(prefix, TB_TRACE_MODULE_NAME, "[warning]: at %s(): %d, %s: " fmt __tb_newline__, __tb_func__, __tb_line__, __tb_file__, __VA_ARGS__); tb_trace_sync(); } while (0)


### PR DESCRIPTION
…llocations.

Hello !
Trying to find the memory leak/fragmentation problem I added this conditional code to see only memory allocations/deallocations and could see that "tb_allocator_malloc_ / tb_allocator_free_" are called twice several times.
```
[tbox]: [allocator]: [warning]: tb_allocator_malloc0_(): 392 at tb_hash_map_init(): 497, src/tbox/container/hash_map.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b214e8): 392 at tb_hash_map_init(): 497, src/tbox/container/hash_map.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b214e8): 392 at tb_hash_map_init(): 497, src/tbox/container/hash_map.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc0_(0x1b214e8): 392 at tb_hash_map_init(): 497, src/tbox/container/hash_map.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b42128): 64 at tb_hash_map_init(): 524, src/tbox/container/hash_map.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b42128): 64 at tb_hash_map_init(): 524, src/tbox/container/hash_map.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc0_(): 568 at tb_stream_init(): 73, src/tbox/stream/stream.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x7fc54948c0c8): 568 at tb_stream_init(): 73, src/tbox/stream/stream.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x7fc54948c0c8): 568 at tb_stream_init(): 73, src/tbox/stream/stream.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc0_(0x7fc54948c0c8): 568 at tb_stream_init(): 73, src/tbox/stream/stream.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x7fc5494e2030): 131072 at tb_queue_buffer_push_init(): 280, src/tbox/memory/queue_buffer.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc0_(): 256 at tb_vector_init(): 201, src/tbox/container/vector.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b47158): 256 at tb_vector_init(): 201, src/tbox/container/vector.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b47158): 256 at tb_vector_init(): 201, src/tbox/container/vector.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc0_(0x1b47158): 256 at tb_vector_init(): 201, src/tbox/container/vector.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b47260): 256 at tb_vector_init(): 228, src/tbox/container/vector.c
[tbox]: [allocator]: [warning]: tb_allocator_malloc_(0x1b47260): 256 at tb_vector_init(): 228, src/tbox/container/vector.c
[tbox]: [allocator]: [warning]: tb_allocator_free_(0x7fc5494e2030) at tb_queue_buffer_exit(): 53, src/tbox/memory/queue_buffer.c
[tbox]: [allocator]: [warning]: tb_allocator_free_(0x7fc54948c0c8) at tb_stream_exit(): 202, src/tbox/stream/stream.c
[tbox]: [allocator]: [warning]: tb_allocator_free_(0x7fc54948c0c8) at tb_stream_exit(): 202, src/tbox/stream/stream.c
```