### PR TITLE
fix copy username/password/database

### DIFF
--- a/src/tbox/database/impl/mysql.c
+++ b/src/tbox/database/impl/mysql.c
@@ -758,7 +758,7 @@ static tb_bool_t tb_database_mysql_open(tb_database_sql_impl_t* database)
                 if (!e) e = args + argn;
 
                 // save username
-                if (p < e) tb_strlcpy(username, p, tb_min(e - p, sizeof(username)));
+                if (p < e) tb_strlcpy(username, p, tb_min((e - p) + 1, sizeof(username)));
             }
     
             // the database password
@@ -773,7 +773,7 @@ static tb_bool_t tb_database_mysql_open(tb_database_sql_impl_t* database)
                 if (!e) e = args + argn;
 
                 // save password
-                if (p < e) tb_strlcpy(password, p, tb_min(e - p, sizeof(password)));
+                if (p < e) tb_strlcpy(password, p, tb_min((e - p) + 1, sizeof(password)));
             }
     
             // the database name
@@ -788,7 +788,7 @@ static tb_bool_t tb_database_mysql_open(tb_database_sql_impl_t* database)
                 if (!e) e = args + argn;
 
                 // save database name
-                if (p < e) tb_strlcpy(database_sql_name, p, tb_min(e - p, sizeof(database_sql_name)));
+                if (p < e) tb_strlcpy(database_sql_name, p, tb_min((e - p) + 1, sizeof(database_sql_name)));
             }
         }
 


### PR DESCRIPTION
src/tbox/database/impl/mysql.c
的tb_database_mysql_open解释username/password后复制的操作有问题：
tb_strlcpy(username, p, tb_min(e - p, sizeof(username)));

如果username=root，则tb_strlcpy(username, p, 4)，只复制了roo, 应该是tb_strlcpy(username,p, 5)才对。

即要修改为tb_min((e-p)+1, sizeof(username)，strlcpy的size参数大小包括字符串的NUL