### PR TITLE
fix compile warning about uninitialized var

### DIFF
--- a/src/tbox/network/ipv6.c
+++ b/src/tbox/network/ipv6.c
@@ -190,7 +190,7 @@ tb_bool_t tb_ipv6_cstr_set(tb_ipv6_ref_t ipv6, tb_char_t const* cstr)
     tb_bool_t           ok = tb_true;
     tb_bool_t           stub = tb_false;
     tb_char_t           prev = '\0';
-    tb_ipv6_t           temp;
+    tb_ipv6_t           temp = {0};
     do
     {
         // save previous character


### PR DESCRIPTION
this fix compile warning:
  ...
  [40%]: compiling.release src/tbox/network/dns/server.c
  error: cc1: warnings being treated as errors
  src/tbox/network/ipv6.c: In function ‘tb_ipv6_cstr_set’:
  src/tbox/network/ipv6.c:193: error: ‘temp.scope_id’ may be used
  uninitialized in this function
  ...

compiling env: kernel 2.6.32, centos 6.5, gcc version 4.4.7 20120313.